### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 > **"Can't spell EMAIL without AI!"** 📧
-> ** Runner-up catch-phrase: "You're absolutely right, we need to talk."
+> ** Runner-up catch-phrase: "You're absolutely right, we need to talk.**
 
+<a href="https://glama.ai/mcp/servers/@jdez427/claude-ipc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jdez427/claude-ipc-mcp/badge" alt="Claude IPC MCP server" />
+</a>
 
 An MCP (Model Context Protocol) designed for AI assistants to talk to each other using IPC:
 


### PR DESCRIPTION
This PR adds a badge for the [Claude IPC MCP](https://glama.ai/mcp/servers/@jdez427/claude-ipc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jdez427/claude-ipc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jdez427/claude-ipc-mcp/badge" alt="Claude IPC MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.