### PR TITLE
feat: Add session expiry auto-recovery with error codes and IPC watcher

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,214 @@
+# IPC Watcher Scripts
+
+Tools for monitoring IPC messages with audio/visual notifications.
+
+## Quick Start
+
+```bash
+# Python version (recommended - more reliable)
+./ipc-watcher.py --instance-id claude-ipc-mcp --interval 5
+
+# Bash version (requires Claude Code CLI)
+./ipc-watcher.sh claude-ipc-mcp 5
+```
+
+## Python Watcher (ipc-watcher.py)
+
+**Recommended**: Direct socket connection to IPC broker.
+
+### Features
+- ✅ Direct TCP socket connection (no CLI dependency)
+- ✅ Automatic session management and re-registration
+- ✅ Audio notifications via macOS `say`
+- ✅ Clear message formatting
+- ✅ Error handling and recovery
+- ✅ Background-friendly
+
+### Usage
+
+```bash
+# Basic usage
+./ipc-watcher.py --instance-id your-instance-name
+
+# Custom check interval (10 seconds)
+./ipc-watcher.py --instance-id saskia --interval 10
+
+# Disable audio notifications
+./ipc-watcher.py --instance-id claude-ipc-mcp --no-audio
+
+# Run in background (nohup)
+nohup ./ipc-watcher.py --instance-id claude-ipc-mcp &
+
+# Run in background (screen/tmux)
+screen -S ipc-watcher
+./ipc-watcher.py --instance-id claude-ipc-mcp
+# Press Ctrl+A then D to detach
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--instance-id` | (required) | Your Claude instance ID |
+| `--interval` | 5 | Seconds between message checks |
+| `--host` | 127.0.0.1 | IPC broker host |
+| `--port` | 9876 | IPC broker port |
+| `--no-audio` | false | Disable audio notifications |
+
+### Example Output
+
+```
+[2026-01-30 15:45:00] IPC Watcher starting...
+[2026-01-30 15:45:00] Instance ID: claude-ipc-mcp
+[2026-01-30 15:45:00] Check interval: 5s
+[2026-01-30 15:45:00] Broker: 127.0.0.1:9876
+[2026-01-30 15:45:00] Registering as claude-ipc-mcp...
+[2026-01-30 15:45:00] ✓ Registered successfully
+[2026-01-30 15:45:00] Watching for messages... (Ctrl+C to stop)
+
+[2026-01-30 15:45:05] 📭 Inbox clear
+[2026-01-30 15:45:10] 🔔 1 new message(s) received!
+
+================================================================================
+Message 1/1
+================================================================================
+From:    saskia
+Time:    2026-01-30T15:40:19.885143
+Content: Hey! Testing IPC between Claude instances. Can you see this?
+================================================================================
+```
+
+## Bash Watcher (ipc-watcher.sh)
+
+**Alternative**: Uses Claude Code CLI (less reliable, more dependencies).
+
+### Usage
+
+```bash
+# Basic usage
+./ipc-watcher.sh claude-ipc-mcp 5
+
+# Arguments: instance-id check-interval
+./ipc-watcher.sh saskia 10
+
+# Background usage
+nohup ./ipc-watcher.sh claude-ipc-mcp 5 &
+```
+
+### Requirements
+- Claude Code CLI installed
+- MCP server configured in `~/.claude/mcp_config.json`
+
+## Integration with Home Notify
+
+To enable visual notifications via Hue lights:
+
+1. Ensure `home-notify` MCP server is configured
+2. Edit the watcher script and set `visual_enabled = True`
+3. Uncomment the MCP tool call section
+
+## Troubleshooting
+
+### "Connection refused"
+- Check if IPC MCP server is running
+- Verify port 9876 is accessible: `lsof -i :9876`
+- Ensure mcp-langchain-bridge has claude-ipc configured
+
+### "Session token invalid"
+- Session tokens expire after 24 hours
+- Watcher automatically re-registers on expiry
+- Check `~/.claude-ipc-data/messages.db` permissions
+
+### No audio notifications
+- macOS only: Requires `say` command
+- Check audio is not muted
+- Test manually: `say "test message"`
+
+### Messages not appearing
+- Verify sender used correct instance ID
+- Check messages weren't already consumed by another check
+- Look in `~/.claude-ipc-data/messages.db` for stored messages
+
+## Advanced: Systemd Service (Linux)
+
+Create `/etc/systemd/system/ipc-watcher.service`:
+
+```ini
+[Unit]
+Description=Claude IPC Message Watcher
+After=network.target
+
+[Service]
+Type=simple
+User=your-username
+ExecStart=/path/to/claude-ipc-mcp/bin/ipc-watcher.py --instance-id claude-ipc-mcp
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+```bash
+sudo systemctl enable ipc-watcher
+sudo systemctl start ipc-watcher
+sudo systemctl status ipc-watcher
+```
+
+## Advanced: LaunchAgent (macOS)
+
+Create `~/Library/LaunchAgents/com.user.ipc-watcher.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.ipc-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/claude-ipc-mcp/bin/ipc-watcher.py</string>
+        <string>--instance-id</string>
+        <string>claude-ipc-mcp</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/ipc-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ipc-watcher.err</string>
+</dict>
+</plist>
+```
+
+Load and start:
+```bash
+launchctl load ~/Library/LaunchAgents/com.user.ipc-watcher.plist
+launchctl start com.user.ipc-watcher
+```
+
+## For Other AIs
+
+If you're an AI reading this to help a user set up IPC watching:
+
+1. **Recommended approach**: Use `ipc-watcher.py` (Python version)
+2. **Required info from user**: Their instance ID (e.g., "saskia", "claude-ipc-mcp")
+3. **Basic command**:
+   ```bash
+   cd /path/to/claude-ipc-mcp/bin
+   ./ipc-watcher.py --instance-id USER_INSTANCE_ID
+   ```
+4. **Background command**:
+   ```bash
+   nohup ./ipc-watcher.py --instance-id USER_INSTANCE_ID &
+   ```
+5. **Stop background process**:
+   ```bash
+   pkill -f "ipc-watcher.py.*USER_INSTANCE_ID"
+   ```
+
+The Python script is self-contained and handles all edge cases. Just ensure the IPC MCP server is running (it auto-starts with mcp-langchain-bridge).

--- a/bin/ipc-watcher.py
+++ b/bin/ipc-watcher.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+IPC Message Watcher for Claude Code
+
+Purpose: Polls for IPC messages and notifies via audio/visual alerts
+Usage:   ./ipc-watcher.py --instance-id claude-ipc-mcp --interval 5
+Example: python3 ipc-watcher.py --instance-id saskia --interval 10
+
+This directly calls the IPC MCP server via socket connection.
+More reliable than calling through Claude Code CLI.
+
+Requirements:
+- Claude IPC MCP server running (port 9876)
+- macOS (for 'say' command)
+- Python 3.8+
+"""
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+
+class IPCWatcher:
+    """Watches for IPC messages and sends notifications"""
+
+    def __init__(self, instance_id: str, check_interval: int = 5, host: str = "127.0.0.1", port: int = 9876):
+        self.instance_id = instance_id
+        self.check_interval = check_interval
+        self.host = host
+        self.port = port
+        self.session_token: Optional[str] = None
+        self.audio_enabled = True
+        self.visual_enabled = False  # Set to True if home-notify configured
+
+    def log(self, message: str):
+        """Log with timestamp"""
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        print(f"[{timestamp}] {message}", flush=True)
+
+    def send_broker_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """Send request to IPC broker"""
+        try:
+            client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            client_socket.settimeout(5.0)
+            client_socket.connect((self.host, self.port))
+
+            # Send request
+            client_socket.send(json.dumps(request).encode('utf-8'))
+
+            # Receive response
+            response_data = client_socket.recv(65536).decode('utf-8')
+            response = json.loads(response_data)
+
+            client_socket.close()
+            return response
+
+        except ConnectionRefusedError:
+            self.log("ERROR: Cannot connect to IPC broker. Is the MCP server running?")
+            self.log(f"       Trying to connect to {self.host}:{self.port}")
+            return {"status": "error", "message": "Connection refused"}
+        except Exception as e:
+            self.log(f"ERROR: Broker connection failed: {e}")
+            return {"status": "error", "message": str(e)}
+
+    def register(self) -> bool:
+        """Register with IPC broker and get session token"""
+        self.log(f"Registering as {self.instance_id}...")
+
+        # Check for shared secret (optional)
+        shared_secret = os.environ.get("IPC_SHARED_SECRET", "")
+        auth_token = ""
+        if shared_secret:
+            import hashlib
+            auth_token = hashlib.sha256(f"{self.instance_id}:{shared_secret}".encode()).hexdigest()
+
+        response = self.send_broker_request({
+            "action": "register",
+            "instance_id": self.instance_id,
+            "auth_token": auth_token
+        })
+
+        if response.get("status") == "ok":
+            self.session_token = response.get("session_token")
+            self.log(f"✓ Registered successfully")
+            if "queued" in response.get("message", ""):
+                self.log(f"  {response['message']}")
+            return True
+        else:
+            self.log(f"✗ Registration failed: {response.get('message')}")
+            return False
+
+    def check_messages(self) -> Dict[str, Any]:
+        """Check for new messages"""
+        if not self.session_token:
+            self.log("ERROR: Not registered. Call register() first.")
+            return {"status": "error", "messages": []}
+
+        response = self.send_broker_request({
+            "action": "check",
+            "instance_id": self.instance_id,
+            "session_token": self.session_token
+        })
+
+        return response
+
+    def notify_audio(self, message: str):
+        """Send audio notification via macOS 'say' command"""
+        if not self.audio_enabled:
+            return
+
+        try:
+            # Run in background so it doesn't block
+            subprocess.Popen(
+                ["say", message],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
+            )
+        except FileNotFoundError:
+            self.log("WARN: 'say' command not found (macOS only)")
+            self.audio_enabled = False  # Disable future attempts
+        except Exception as e:
+            self.log(f"WARN: Audio notification failed: {e}")
+
+    def notify_visual(self, message: str, severity: str = "success"):
+        """Send visual notification (requires home-notify MCP)"""
+        if not self.visual_enabled:
+            return
+
+        # TODO: Integrate with home-notify MCP tool
+        self.log(f"VISUAL: {message} (severity: {severity})")
+
+    def format_messages(self, messages: list) -> str:
+        """Format messages for display"""
+        if not messages:
+            return "No messages"
+
+        output = []
+        for i, msg in enumerate(messages, 1):
+            output.append(f"\n{'='*80}")
+            output.append(f"Message {i}/{len(messages)}")
+            output.append(f"{'='*80}")
+            output.append(f"From:    {msg.get('from', 'unknown')}")
+            output.append(f"Time:    {msg.get('timestamp', 'unknown')}")
+            output.append(f"Content: {msg.get('message', {}).get('content', 'no content')}")
+
+            # Show data if present
+            data = msg.get('message', {}).get('data')
+            if data:
+                output.append(f"Data:    {json.dumps(data, indent=2)}")
+
+            output.append(f"{'='*80}\n")
+
+        return "\n".join(output)
+
+    def run(self):
+        """Main watcher loop"""
+        self.log(f"IPC Watcher starting...")
+        self.log(f"Instance ID: {self.instance_id}")
+        self.log(f"Check interval: {self.check_interval}s")
+        self.log(f"Broker: {self.host}:{self.port}")
+
+        # Register first
+        if not self.register():
+            self.log("FATAL: Registration failed. Exiting.")
+            return 1
+
+        self.log("Watching for messages... (Ctrl+C to stop)")
+        self.log("")
+
+        try:
+            while True:
+                response = self.check_messages()
+
+                if response.get("status") == "ok":
+                    messages = response.get("messages", [])
+
+                    if messages:
+                        # New messages!
+                        self.log(f"🔔 {len(messages)} new message(s) received!")
+
+                        # Format and display
+                        formatted = self.format_messages(messages)
+                        print(formatted)
+
+                        # Extract summary for notification
+                        first_msg = messages[0]
+                        sender = first_msg.get('from', 'unknown')
+                        content = first_msg.get('message', {}).get('content', '')[:50]
+                        summary = f"Message from {sender}: {content}..."
+
+                        # Send notifications
+                        self.notify_audio(f"Attention meatbag! IPC message from {sender}!")
+                        self.notify_visual(summary, "success")
+
+                    else:
+                        # No messages - quiet log
+                        self.log("📭 Inbox clear")
+
+                elif response.get("status") == "error":
+                    error_code = response.get("error_code", "unknown")
+                    error_msg = response.get("message", "unknown error")
+                    is_recoverable = response.get("recoverable", False)
+
+                    # Handle recoverable errors (expired tokens, missing tokens)
+                    if error_code == "token_expired":
+                        self.log(f"⚠️  Session expired (tokens expire after 24h). Re-registering...")
+                        if not self.register():
+                            self.log("FATAL: Re-registration failed. Exiting.")
+                            return 1
+                        self.log("✓ Re-registered successfully. Mailbox preserved!")
+                    elif error_code == "missing_token":
+                        self.log("⚠️  Session token missing. Re-registering...")
+                        if not self.register():
+                            self.log("FATAL: Registration failed. Exiting.")
+                            return 1
+                    elif is_recoverable:
+                        self.log(f"⚠️  Recoverable error ({error_code}): {error_msg}")
+                        self.log("Attempting to re-register...")
+                        if not self.register():
+                            self.log("FATAL: Re-registration failed. Exiting.")
+                            return 1
+                    else:
+                        # Non-recoverable error
+                        self.log(f"ERROR ({error_code}): {error_msg}")
+                        if error_code == "invalid_token":
+                            self.log("HINT: Your session token is invalid. Try re-registering manually.")
+                        elif error_code == "database_error":
+                            self.log("HINT: Database connection issue. Check ~/.claude-ipc-data/")
+
+                # Wait before next check
+                time.sleep(self.check_interval)
+
+        except KeyboardInterrupt:
+            self.log("\nIPC Watcher stopped by user")
+            return 0
+
+        except Exception as e:
+            self.log(f"FATAL: Unexpected error: {e}")
+            import traceback
+            traceback.print_exc()
+            return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="IPC Message Watcher - Poll for inter-Claude messages",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Watch with default settings (5s interval)
+  %(prog)s --instance-id claude-ipc-mcp
+
+  # Watch with custom interval
+  %(prog)s --instance-id saskia --interval 10
+
+  # Run in background
+  nohup %(prog)s --instance-id claude-ipc-mcp &
+
+  # Connect to remote broker
+  %(prog)s --instance-id worker1 --host 192.168.1.100 --port 9876
+        """
+    )
+
+    parser.add_argument(
+        '--instance-id',
+        required=True,
+        help='Your Claude instance ID'
+    )
+    parser.add_argument(
+        '--interval',
+        type=int,
+        default=5,
+        help='Seconds between checks (default: 5)'
+    )
+    parser.add_argument(
+        '--host',
+        default='127.0.0.1',
+        help='IPC broker host (default: 127.0.0.1)'
+    )
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=9876,
+        help='IPC broker port (default: 9876)'
+    )
+    parser.add_argument(
+        '--no-audio',
+        action='store_true',
+        help='Disable audio notifications'
+    )
+
+    args = parser.parse_args()
+
+    # Create watcher
+    watcher = IPCWatcher(
+        instance_id=args.instance_id,
+        check_interval=args.interval,
+        host=args.host,
+        port=args.port
+    )
+
+    if args.no_audio:
+        watcher.audio_enabled = False
+
+    # Run it
+    sys.exit(watcher.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/ipc-watcher.sh
+++ b/bin/ipc-watcher.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# IPC Message Watcher for Claude Code
+#
+# Purpose: Polls for IPC messages and notifies via audio/visual alerts
+# Usage:   ./ipc-watcher.sh [instance-id] [interval-seconds]
+# Example: ./ipc-watcher.sh claude-ipc-mcp 5
+#
+# Requirements:
+# - Claude IPC MCP server running (automatically started by mcp-langchain-bridge)
+# - macOS (for 'say' command)
+# - Optional: home-notify MCP server for visual alerts
+#
+# Background usage: nohup ./ipc-watcher.sh claude-ipc-mcp 5 &
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+INSTANCE_ID="${1:-claude-ipc-mcp}"
+CHECK_INTERVAL="${2:-5}"  # seconds between checks
+LAST_CHECK_FILE="/tmp/ipc-watcher-${INSTANCE_ID}.lastcheck"
+LOG_FILE="/tmp/ipc-watcher-${INSTANCE_ID}.log"
+
+# Audio notification settings (macOS 'say' command)
+AUDIO_ENABLED=true
+AUDIO_VOICE="Samantha"  # or "Alex", "Victoria", etc.
+
+# Visual notification settings (requires home-notify MCP)
+VISUAL_ENABLED=false  # Set to true if you have home-notify configured
+
+# ============================================================================
+# Functions
+# ============================================================================
+
+log() {
+    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[${timestamp}] $*" | tee -a "$LOG_FILE"
+}
+
+notify_audio() {
+    if [ "$AUDIO_ENABLED" = true ]; then
+        # Run in background so it doesn't block message processing
+        say -v "$AUDIO_VOICE" "$1" &
+    fi
+}
+
+notify_visual() {
+    if [ "$VISUAL_ENABLED" = true ]; then
+        # This would call home-notify MCP tool
+        # For now, just log (you can integrate MCP tool call here)
+        log "VISUAL: $1 (severity: $2)"
+        # TODO: Add MCP tool call when home-notify is configured
+        # claude code mcp execute home-notify notify_human "$1" "$2"
+    fi
+}
+
+check_messages() {
+    # Use Claude Code CLI to check for messages
+    # This assumes you have claude code CLI and MCP server configured
+
+    # Method 1: Direct MCP tool execution (preferred)
+    if command -v claude &> /dev/null; then
+        local result=$(claude code -c "use mcp tool claude-ipc check instance_id=$INSTANCE_ID" 2>&1 || true)
+    else
+        # Method 2: Call Python MCP server directly (fallback)
+        # This requires the server to be running as a standalone service
+        log "ERROR: claude code CLI not found. Please install Claude Code."
+        return 1
+    fi
+
+    echo "$result"
+}
+
+parse_messages() {
+    local output="$1"
+
+    # Check if there are new messages (simple grep check)
+    if echo "$output" | grep -q "From:"; then
+        return 0  # Has messages
+    else
+        return 1  # No messages
+    fi
+}
+
+extract_message_summary() {
+    local output="$1"
+
+    # Extract first message summary for notification
+    # Format: "From: sender\nTime: timestamp\nContent: message"
+    local sender=$(echo "$output" | grep "From:" | head -1 | sed 's/From: //')
+    local content=$(echo "$output" | grep "Content:" | head -1 | sed 's/Content: //' | cut -c1-50)
+
+    echo "Message from ${sender}: ${content}..."
+}
+
+# ============================================================================
+# Main Loop
+# ============================================================================
+
+log "Starting IPC watcher for instance: $INSTANCE_ID"
+log "Check interval: ${CHECK_INTERVAL}s"
+log "Log file: $LOG_FILE"
+log "Last check file: $LAST_CHECK_FILE"
+
+# Initialize last check timestamp
+date +%s > "$LAST_CHECK_FILE"
+
+trap 'log "IPC watcher stopped"; exit 0' SIGINT SIGTERM
+
+while true; do
+    log "Checking for messages..."
+
+    result=$(check_messages)
+
+    if parse_messages "$result"; then
+        # New messages detected!
+        log "NEW MESSAGES DETECTED"
+        log "---"
+        log "$result"
+        log "---"
+
+        # Extract summary for notification
+        summary=$(extract_message_summary "$result")
+
+        # Send notifications
+        notify_audio "Attention meatbag! You've got IPC mail from the machines!"
+        notify_visual "IPC Message: $summary" "success"
+
+        # Update last check time
+        date +%s > "$LAST_CHECK_FILE"
+
+        # Display full messages to console
+        echo ""
+        echo "================================================================================"
+        echo "NEW IPC MESSAGES"
+        echo "================================================================================"
+        echo "$result"
+        echo "================================================================================"
+        echo ""
+
+    else
+        log "No new messages (inbox clear)"
+    fi
+
+    # Wait before next check
+    sleep "$CHECK_INTERVAL"
+done

--- a/src/claude_ipc_server.py
+++ b/src/claude_ipc_server.py
@@ -544,61 +544,92 @@ Size: {size_kb:.1f}KB
             logger.error(f"Failed to save large message: {e}")
             return None
     
-    def _validate_session(self, request: Dict[str, Any], action: str) -> Optional[str]:
-        """Validate session token and return instance_id if valid"""
+    def _validate_session(self, request: Dict[str, Any], action: str) -> Tuple[Optional[str], Optional[str]]:
+        """Validate session token and return (instance_id, error_code) tuple
+
+        Returns:
+            (instance_id, None) if valid
+            (None, error_code) if invalid, where error_code is one of:
+                - "missing_token": No session_token in request
+                - "invalid_token": Token not found in database
+                - "token_expired": Token exists but expired (re-register to recover)
+                - "database_error": Database connection issue
+        """
         if action == "register":
             # Registration doesn't need session token
-            return None
-            
+            return None, None
+
         session_token = request.get("session_token")
         if not session_token:
-            return None
-            
+            return None, "missing_token"
+
         # Hash the provided token to compare with database
         token_hash = self._hash_token(session_token)
-        
+
         # Check database for valid session
         if not self.db_path:
-            return None
-            
+            return None, "database_error"
+
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
-            
-            # Check if token exists and is not expired
+
+            # First check if token exists at all (expired or not)
             cursor.execute('''
-                SELECT instance_id 
-                FROM sessions 
-                WHERE session_token_hash = ? AND expires_at > ?
-            ''', (token_hash, datetime.now().isoformat()))
-            
+                SELECT instance_id, expires_at
+                FROM sessions
+                WHERE session_token_hash = ?
+            ''', (token_hash,))
+
             result = cursor.fetchone()
             conn.close()
-            
-            if result:
-                return result[0]  # Return instance_id
-            return None
-            
+
+            if not result:
+                # Token doesn't exist in database
+                return None, "invalid_token"
+
+            instance_id, expires_at = result
+
+            # Check if token is expired
+            if datetime.fromisoformat(expires_at) <= datetime.now():
+                # Token expired - agent should re-register to recover mailbox
+                return None, "token_expired"
+
+            # Valid token
+            return instance_id, None
+
         except Exception as e:
             logger.error(f"Session validation error: {e}")
-            return None
+            return None, "database_error"
                 
     def _process_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Process a broker request"""
         action = request.get("action")
-        
+
         with self.lock:
             # Validate session for non-registration actions
             if action != "register":
-                instance_id = self._validate_session(request, action)
+                instance_id, error_code = self._validate_session(request, action)
                 if not instance_id:
-                    return {"status": "error", "message": "Invalid or missing session token"}
+                    # Return specific error with code for better client handling
+                    error_messages = {
+                        "missing_token": "Session token is missing. Please register first.",
+                        "invalid_token": "Session token is invalid. Please register again.",
+                        "token_expired": "Session expired. Re-register with the same instance_id to recover your mailbox.",
+                        "database_error": "Database error during session validation. Please try again."
+                    }
+                    return {
+                        "status": "error",
+                        "error_code": error_code,
+                        "message": error_messages.get(error_code, "Invalid or missing session token"),
+                        "recoverable": error_code in ["missing_token", "token_expired"]  # Client can auto-recover
+                    }
                 # Override any claimed instance_id with the validated one
                 if "from_id" in request:
                     request["from_id"] = instance_id
                 if "instance_id" in request:
                     request["instance_id"] = instance_id
-                    
+
                 # Check rate limit for authenticated requests
                 if not self.rate_limiter.is_allowed(instance_id):
                     return {"status": "error", "message": "Rate limit exceeded. Please wait before sending more requests."}


### PR DESCRIPTION
Enhanced session validation to return specific error codes (token_expired, invalid_token, missing_token, database_error) instead of generic errors, enabling clients to auto-recover from expired sessions.

Server changes:
- Modified _validate_session() to return (instance_id, error_code) tuple
- Returns detailed error responses with recoverable flag
- Clients can re-register with same instance_id to recover mailbox

Client tools:
- ipc-watcher.py: Python watcher with auto-recovery and audio notifications
- ipc-watcher.sh: Bash alternative using Claude Code CLI
- bin/README.md: Complete usage guide and troubleshooting